### PR TITLE
PKG-17870 win test fix

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0395fa126940340215090c344a2bf4e2a77bcbe7daab16f41b37b98c95809ff9
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -38,7 +38,7 @@ test:
   requires:
     - pip
     - pytest
-    - git  # [linux]
+    - git
 
 about:
   home: https://pypi.org/project/hatch-vcs


### PR DESCRIPTION
hatch-vcs 0.5.0

**Destination channel:** Defaults

### Links

- [PKG-17870]

### Explanation of changes:
- add **git** to the test environment on Windows by removing the Linux-only selector
- required for **hatch-vcs** tests that invoke Git during downstream validation

### Validation:
- https://github.com/AnacondaRecipes/hatch-vcs-feedstock/pull/7 🟢 

[PKG-17870]: https://anaconda.atlassian.net/browse/PKG-17870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ